### PR TITLE
Fixed Effort Rolls in 1E Actor Sheets

### DIFF
--- a/templates/actor/character-sheet.html
+++ b/templates/actor/character-sheet.html
@@ -98,7 +98,7 @@
                     <div class="resource effort {{id}}">
                         <label for="data.effort.{{id}}.value"
                             class="resource-label {{#icrpg-is id 'magic'}}d8{{else}}{{eff.die}}{{/icrpg-is}} rollable"
-                            data-roll='{{#icrpg-is id "magic"}}1d8{{else}}{{eff.die}}{{/icrpg-is}}+{{eff.value}}'
+                            data-roll='1{{#icrpg-is id "magic"}}d8{{else}}{{eff.die}}{{/icrpg-is}}+{{eff.value}}'
                             data-label='{{localize (icrpg-concat "ICRPG.Effort" (icrpg-capitalize id))}}'>
                             {{localize (icrpg-concat "ICRPG.Effort" (icrpg-capitalize id))}}
                         </label>

--- a/templates/actor/npc-sheet.html
+++ b/templates/actor/npc-sheet.html
@@ -101,7 +101,7 @@
                     {{#with (lookup ../data.effort id) as |eff|}}
                     <div class="resource effort {{id}}">
                         <label for="data.effort.{{id}}.value" class="resource-label {{eff.die}} rollable"
-                        data-roll='{{#icrpg-is id "magic"}}1d8{{else}}{{eff.die}}{{/icrpg-is}}+{{eff.value}}'
+                        data-roll='1{{#icrpg-is id "magic"}}d8{{else}}{{eff.die}}{{/icrpg-is}}+{{eff.value}}'
                             data-label='{{localize (icrpg-concat "ICRPG.Effort" (icrpg-capitalize id))}}'>
                             {{localize (icrpg-concat "ICRPG.Effort" (icrpg-capitalize id))}}
                         </label>


### PR DESCRIPTION
A suggested fix for the Issue I raised about Effort Rolls in the 1E Actor Sheets.
With this change the data-roll attribute of the Effort fields gets a 1 at the start of the formula, like the 2E Actor Sheets, which made the roll fomulas work in FoundryVTT.
The "1" in "1d8" of the subsequent condition for "Magic Effort" becomes redundant and thus reduced to "d8".