### PR TITLE
Expanding Item/Ability capabilities in ICRPG

### DIFF
--- a/css/icrpg.css
+++ b/css/icrpg.css
@@ -179,7 +179,9 @@ input::-moz-selection {
 }
 
 .icrpg.sheet.item .item-form .sheet-tabs {
-  display: none;
+  -webkit-box-flex: 1;
+      -ms-flex: 1 0 40%;
+          flex: 1 0 40%;
 }
 
 .icrpg .sheet-header {

--- a/lang/de.json
+++ b/lang/de.json
@@ -46,5 +46,20 @@
     "ICRPG.Notes": "Notizen",
     "ICRPG.Description": "Beschreibung",
     "ICRPG.Rolling": "Würfelt",
-    "ICRPG.Mastery": "Meisterschaft"
+    "ICRPG.Mastery": "Meisterschaft",
+    "ICRPG.Effects": "Effects",
+    "ICRPG.Rolls": "Rolls",
+    "ICRPG.ItemEffects": "Item Effects",
+    "ICRPG.Source": "Source",
+    "ICRPG.Duration": "Duration",
+    "ICRPG.EffectCreate": "Create Effects",
+    "ICRPG.EffectToggle": "Toggle Effects",
+    "ICRPG.EffectEdit": "Edit Effects",
+    "ICRPG.EffectDelete": "Delete Effects",
+    "ICRPG.StatRollFormula": "Stat Roll Formula",
+    "ICRPG.EffortRollFormula": "Effort Roll Formula",
+    "ICRPG.Add": "Add",
+    "ICRPG.StatRoll": "Stat Roll",
+    "ICRPG.EffortRoll": "Effort Roll",
+    "ICRPG.AbilityEffects": "Ability Effects"
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -46,5 +46,20 @@
     "ICRPG.Notes": "Notes",
     "ICRPG.Description": "Description",
     "ICRPG.Rolling": "Rolling",
-    "ICRPG.Mastery": "Mastery"
+    "ICRPG.Mastery": "Mastery",
+    "ICRPG.Effects": "Effects",
+    "ICRPG.Rolls": "Rolls",
+    "ICRPG.ItemEffects": "Item Effects",
+    "ICRPG.Source": "Source",
+    "ICRPG.Duration": "Duration",
+    "ICRPG.EffectCreate": "Create Effects",
+    "ICRPG.EffectToggle": "Toggle Effects",
+    "ICRPG.EffectEdit": "Edit Effects",
+    "ICRPG.EffectDelete": "Delete Effects",
+    "ICRPG.StatRollFormula": "Stat Roll Formula",
+    "ICRPG.EffortRollFormula": "Effort Roll Formula",
+    "ICRPG.Add": "Add",
+    "ICRPG.StatRoll": "Stat Roll",
+    "ICRPG.EffortRoll": "Effort Roll",
+    "ICRPG.AbilityEffects": "Ability Effects"
 }

--- a/lang/es.json
+++ b/lang/es.json
@@ -46,5 +46,20 @@
     "ICRPG.Notes": "Notas",
     "ICRPG.Description": "Descripción",
     "ICRPG.Rolling": "Lanzando",
-    "ICRPG.Mastery": "Maestría"
+    "ICRPG.Mastery": "Maestría",
+    "ICRPG.Effects": "Effects",
+    "ICRPG.Rolls": "Rolls",
+    "ICRPG.ItemEffects": "Item Effects",
+    "ICRPG.Source": "Source",
+    "ICRPG.Duration": "Duration",
+    "ICRPG.EffectCreate": "Create Effects",
+    "ICRPG.EffectToggle": "Toggle Effects",
+    "ICRPG.EffectEdit": "Edit Effects",
+    "ICRPG.EffectDelete": "Delete Effects",
+    "ICRPG.StatRollFormula": "Stat Roll Formula",
+    "ICRPG.EffortRollFormula": "Effort Roll Formula",
+    "ICRPG.Add": "Add",
+    "ICRPG.StatRoll": "Stat Roll",
+    "ICRPG.EffortRoll": "Effort Roll",
+    "ICRPG.AbilityEffects": "Ability Effects"
 }

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -46,5 +46,20 @@
     "ICRPG.Notes": "Notities",
     "ICRPG.Description": "Omschrijving",
     "ICRPG.Rolling": "Rolt",
-    "ICRPG.Mastery": "Meesterschap"
+    "ICRPG.Mastery": "Meesterschap",
+    "ICRPG.Effects": "Effects",
+    "ICRPG.Rolls": "Rolls",
+    "ICRPG.ItemEffects": "Item Effects",
+    "ICRPG.Source": "Source",
+    "ICRPG.Duration": "Duration",
+    "ICRPG.EffectCreate": "Create Effects",
+    "ICRPG.EffectToggle": "Toggle Effects",
+    "ICRPG.EffectEdit": "Edit Effects",
+    "ICRPG.EffectDelete": "Delete Effects",
+    "ICRPG.StatRollFormula": "Stat Roll Formula",
+    "ICRPG.EffortRollFormula": "Effort Roll Formula",
+    "ICRPG.Add": "Add",
+    "ICRPG.StatRoll": "Stat Roll",
+    "ICRPG.EffortRoll": "Effort Roll",
+    "ICRPG.AbilityEffects": "Ability Effects"
 }

--- a/module/actor/character-sheet.js
+++ b/module/actor/character-sheet.js
@@ -45,6 +45,20 @@ export class IcrpgCharacterSheet extends ActorSheet {
 
     // Rollable abilities.
     html.find('.rollable').click(this._onRoll.bind(this));
+	
+	// Drag events for macros.
+	if (this.actor.owner) {
+	  let handler = ev => this._onDragStart(ev);
+	  // Find all items on the character sheet.
+	  html.find('li.item').each((i, li) => {
+		// Ignore for the header row.
+		if (li.classList.contains("item-header")) return;
+		// Add draggable attribute and dragstart listener.
+		li.setAttribute("draggable", true);
+		li.addEventListener("dragstart", handler, false);
+	  });
+	}
+	
   }
 
   /* -------------------------------------------- */
@@ -134,7 +148,16 @@ export class IcrpgCharacterSheet extends ActorSheet {
     event.preventDefault();
     const element = event.currentTarget;
     const dataset = element.dataset;
-
+	
+	// Check if we are clicking on a rollable item
+	let li = $(event.currentTarget).parents(".item");
+	let item = this.actor.items.get(li.data("item-id"));
+	
+	if (item) { // Roll the item according to the roll function in the item sheet 
+		item.roll(); 
+	}
+	
+	// Check if there is a roll already defined in the HTML object's data
     if (dataset.roll) {
       let roll = new Roll(dataset.roll, this.actor.data.data);
       let label = dataset.label ? `${game.i18n.localize("ICRPG.Rolling")} ${dataset.label}` : '';

--- a/module/effects.js
+++ b/module/effects.js
@@ -1,0 +1,27 @@
+/**
+ * Manage Active Effect instances through the Actor Sheet via effect control buttons.
+ * @param {MouseEvent} event      The left-click event on the effect control
+ * @param {Actor|Item} owner      The owning entity which manages this effect
+ */
+export function onManageActiveEffect(event, owner) {
+  event.preventDefault();
+  const a = event.currentTarget;
+  const li = a.closest("li");
+  const effect = li.dataset.effectId ? owner.effects.get(li.dataset.effectId) : null;
+  switch ( a.dataset.action ) {
+    case "create":
+      return owner.createEmbeddedDocuments("ActiveEffect", [{
+        label: "New Effect",
+        icon: "icons/svg/aura.svg",
+        origin: owner.uuid,
+        "duration.rounds": li.dataset.effectType === "temporary" ? 1 : undefined,
+        disabled: li.dataset.effectType === "inactive"
+      }]);
+    case "edit":
+      return effect.sheet.render(true);
+    case "delete":
+      return effect.delete();
+    case "toggle":
+      return effect.update({disabled: !effect.data.disabled});
+  }
+}

--- a/module/icrpg.js
+++ b/module/icrpg.js
@@ -15,7 +15,8 @@ Hooks.once('init', async function () {
   game.icrpg = {
     IcrpgActor,
     IcrpgItem,
-    IcrpgUtility
+    IcrpgUtility,
+    rollItemMacro
   };
 
   /**
@@ -42,4 +43,60 @@ Hooks.once('init', async function () {
   Items.registerSheet("icrpg", IcrpgAbilitySheet, { types: ["ability"], makeDefault: true });
 
   IcrpgRegisterHelpers.init();
+  
 });
+
+Hooks.once("ready", async function() {
+  // Wait to register hotbar drop hook on ready so that modules could register earlier if they want to
+  Hooks.on("hotbarDrop", (bar, data, slot) => createICRPGMacro(data, slot));
+});
+
+/* -------------------------------------------- */
+/*  Hotbar Macros                               */
+/* -------------------------------------------- */
+
+/**
+ * Create a Macro from an Item drop.
+ * Get an existing item macro if one exists, otherwise create a new one.
+ * @param {Object} data     The dropped data
+ * @param {number} slot     The hotbar slot to use
+ * @returns {Promise}
+ */
+async function createICRPGMacro(data, slot) {
+  if (data.type !== "Item") return;
+  if (!("data" in data)) return ui.notifications.warn("You can only create macro buttons for owned Items");
+  const item = data.data;
+
+  // Create the macro command
+  const command = `game.icrpg.rollItemMacro("${item.name}");`;
+  let macro = game.macros.entities.find(m => (m.name === item.name) && (m.command === command));
+  if (!macro) {
+    macro = await Macro.create({
+      name: item.name,
+      type: "script",
+      img: item.img,
+      command: command,
+      flags: { "icrpg.itemMacro": true }
+    });
+  }
+  game.user.assignHotbarMacro(macro, slot);
+  return false;
+}
+
+/**
+ * Create a Macro from an Item drop.
+ * Get an existing item macro if one exists, otherwise create a new one.
+ * @param {string} itemName
+ * @return {Promise}
+ */
+function rollItemMacro(itemName) {
+  const speaker = ChatMessage.getSpeaker();
+  let actor;
+  if (speaker.token) actor = game.actors.tokens[speaker.token];
+  if (!actor) actor = game.actors.get(speaker.actor);
+  const item = actor ? actor.items.find(i => i.name === itemName) : null;
+  if (!item) return ui.notifications.warn(`Your controlled Actor does not have an item named ${itemName}`);
+
+  // Trigger the item roll
+  return item.roll();
+}

--- a/module/item/item-sheet.js
+++ b/module/item/item-sheet.js
@@ -2,6 +2,9 @@
  * Extend the basic ItemSheet with some very simple modifications
  * @extends {ItemSheet}
  */
+ import {onManageActiveEffect} from "../effects.js";
+
+ 
 export class IcrpgItemSheet extends ItemSheet {
 
   /** @override */
@@ -50,7 +53,10 @@ export class IcrpgItemSheet extends ItemSheet {
   /** @override */
   activateListeners(html) {
     super.activateListeners(html);
-
+	html.find(".effect-control").click(ev => {
+        if ( this.item.isOwned ) return ui.notifications.warn("Managing Active Effects within an Owned Item is not currently supported and will be added in a subsequent update.")
+        onManageActiveEffect(ev, this.item)
+      });
     // Everything below here is only needed if the sheet is editable
     if (!this.options.editable) return;
 

--- a/module/item/item.js
+++ b/module/item/item.js
@@ -14,4 +14,28 @@ export class IcrpgItem extends Item {
     const actorData = this.actor ? this.actor.data : {};
     const data = itemData.data;
   }
+  
+  async roll(){ 
+  
+	// Roll the stat roll if it is defined (example - to hit an enemy)
+	let statRoll = this.data.data.statRoll;
+	if (statRoll) {
+		let roll = new Roll(statRoll, this.actor.data.data);
+		roll.evaluate({async: false}).toMessage({
+			speaker: ChatMessage.getSpeaker({ actor: this.actor }),
+			flavor: "<img src=\""+ this.img + "\"width=\"36\" height=\"36\"/><br>" + this.data.data.description + "Stat Roll: "
+		  });
+	}
+	
+	// Roll the effort roll if it is defined (example - how much damage done to an enemy)
+	let effortRoll = this.data.data.effortRoll;
+	if (effortRoll) {
+		let rollTwo = new Roll(effortRoll, this.actor.data.data);
+		rollTwo.evaluate({async: false}).toMessage({
+			speaker: ChatMessage.getSpeaker({ actor: this.actor }),
+			flavor: "<img src=\""+ this.img + "\"width=\"36\" height=\"36\"/><br>" + this.data.data.description + "Effort Roll: "
+		  });
+		}
+  }
+
 }

--- a/template.json
+++ b/template.json
@@ -135,7 +135,9 @@
     ],
     "templates": {
       "base": {
-        "description": ""
+        "description": "",
+        "statRoll": "",
+        "effortRoll": ""
       }
     },
     "item": {

--- a/templates/actor/character-sheet-2e.html
+++ b/templates/actor/character-sheet-2e.html
@@ -194,7 +194,7 @@
                 {{#each actor.items as |item id|}}
                 {{#icrpg-is item.type "ability"}}
                 <li class="item flexrow" data-item-id="{{item.id}}">
-                    <div class="item-image"><img src="{{item.img}}" title="{{item.name}}" width="24" height="24" />
+                    <div class="item-image rollable"><img src="{{item.img}}" title="{{item.name}}" width="24" height="24" />
                     </div>
                     <span class="item-name">
                         <a class="item-control" data-action="edit">{{item.name}}</a>
@@ -236,7 +236,7 @@
                 {{#icrpg-is item.type "item"}}
                 <li class="item flexrow" data-item-id="{{item.id}}"
                     data-filterable="{{#if item.data.data.equipped}}equipped{{else}}unequipped{{/if}}">
-                    <div class="item-image"><img src="{{item.img}}" title="{{item.name}}" width="24" height="24" />
+                    <div class="item-image rollable"><img src="{{item.img}}" title="{{item.name}}" width="24" height="24" />
                     </div>
                     <span class="item-name">
                         <a class="item-control"

--- a/templates/actor/character-sheet.html
+++ b/templates/actor/character-sheet.html
@@ -191,7 +191,7 @@
                 {{#icrpg-is item.type "item"}}
                 <li class="item flexrow" data-item-id="{{item.id}}"
                     data-filterable="{{#if item.data.data.equipped}}equipped{{else}}unequipped{{/if}}">
-                    <div class="item-image"><img src="{{item.img}}" title="{{item.name}}" width="24" height="24" />
+                    <div class="item-image rollable"><img src="{{item.img}}" title="{{item.name}}" width="24" height="24" />
                     </div>
                     <span class="item-name">
                         <a class="item-control"

--- a/templates/item/ability-sheet.html
+++ b/templates/item/ability-sheet.html
@@ -24,7 +24,8 @@
     {{!-- Sheet Tab Navigation --}}
     <nav class="sheet-tabs tabs" data-group="primary">
         <a class="item" data-tab="description">{{localize "ICRPG.Description"}}</a>
-        <!--<a class="item" data-tab="attributes">{{localize "ICRPG.Attributes"}}</a>-->
+        <a class="item" data-tab="effects">{{localize "ICRPG.Effects"}}</a>
+		<a class="item" data-tab="rolls">{{localize "ICRPG.Rolls"}}</a>
     </nav>
 
     {{!-- Sheet Body --}}
@@ -34,12 +35,57 @@
         <div class="tab" data-group="primary" data-tab="description">
             {{editor content=data.data.description target="data.description" button=true owner=owner editable=editable}}
         </div>
-        <!--
-        {{!-- Attributes Tab --}}
-        <div class="tab attributes" data-group="primary" data-tab="attributes">
-            {{!-- As you add new fields, add them in here! --}}
+        
+		{{!-- Effects Tab --}}
+        <div class="tab effects" data-group="primary" data-tab="effects">
+            <ol class="items-list effects-list">
+				<li class="item-header flexrow" data-effect-type="Item Effects">
+					<h3 class="item-name effect-name flexrow">{{localize "ICRPG.AbilityEffects"}}</h3>
+					<div class="effect-source">{{localize "ICRPG.Source"}}</div>
+					<div class="effect-source">{{localize "ICRPG.Duration"}}</div>
+					<div class="item-controls effect-controls flexrow">
+						<a class="effect-control" data-action="create" title="{{localize 'ICRPG.EffectCreate'}}">
+							<i class="fas fa-plus"></i> {{localize "ICRPG.Add"}}
+						</a>
+					</div>
+				</li>
+
+				<ol class="item-list">
+				{{#each item.effects as |effect|}}
+					<li class="item effect flexrow" data-effect-id="{{effect.id}}">
+						<div class="item-name flexrow">
+							<h4>{{effect.data.label}}</h4>
+						</div>
+						<div class="effect-source">{{effect.sourceName}}</div>
+						<div class="effect-duration">{{effect.duration.label}}</div>
+						<div class="item-controls effect-controls flexrow">
+							<a class="effect-control" data-action="toggle" title="{{localize 'ICRPG.EffectToggle'}}">
+								<i class="fas {{#if effect.data.disabled}}fa-check{{else}}fa-times{{/if}}"></i>
+							</a>
+							<a class="effect-control" data-action="edit" title="{{localize 'ICRPG.EffectEdit'}}">
+								<i class="fas fa-edit"></i>
+							</a>
+							<a class="effect-control" data-action="delete" title="{{localize 'ICRPG.EffectDelete'}}">
+								<i class="fas fa-trash"></i>
+							</a>
+						</div>
+					</li>
+				{{/each}}
+					</ol>
+				</ol>
         </div>
--->
+		
+		{{!-- Rolls Tab --}}
+		<div class="tab rolls" data-group="primary" data-tab="rolls">
+			<div class="resource-content flexrow flex-center flex-between">
+				<label class="resource-label"> Stat Roll Formula:  </label>
+				<input type="text" name="data.statRoll" value="{{data.data.statRoll}}"/>
+			</div>
+			<div class="resource-content flexrow flex-center flex-between">
+				<label class="resource-label"> Effort Roll Formula:  </label>
+				<input type="text" name="data.effortRoll" value="{{data.data.effortRoll}}"/>
+			</div>
+		</div>
     </section>
 
 </form>

--- a/templates/item/item-sheet.html
+++ b/templates/item/item-sheet.html
@@ -1,9 +1,9 @@
 <form class="{{cssClass}} item-form" autocomplete="off">
 
     {{!-- Sheet Header --}}
-    <header class="sheet-header">
+    <header class="sheet-header">	
         <img class="profile-img" src="{{item.img}}" data-edit="img" title="{{item.name}}" />
-        <div class="header-fields">
+		<div class="header-fields">
             <h1 class="charname"><input name="name" type="text" value="{{item.name}}" placeholder="Name" /></h1>
             <div class="resource grid grid-2col">
                 <div class="resource flex-group-center">
@@ -22,22 +22,68 @@
     {{!-- Sheet Tab Navigation --}}
     <nav class="sheet-tabs tabs" data-group="primary">
         <a class="item" data-tab="description">{{localize "ICRPG.Description"}}</a>
-        <!--<a class="item" data-tab="attributes">{{localize "ICRPG.Attributes"}}</a>-->
+        <a class="item" data-tab="effects">{{localize "ICRPG.Effects"}}</a>
+		<a class="item" data-tab="rolls">{{localize "ICRPG.Rolls"}}</a>
     </nav>
 
     {{!-- Sheet Body --}}
     <section class="sheet-body">
 
-        {{!-- Description Tab --}}
-        <div class="tab" data-group="primary" data-tab="description">
+        {{!-- Description Tab --}}		
+        <div class="tab description" data-group="primary" data-tab="description">
             {{editor content=data.data.description target="data.description" button=true owner=owner editable=editable}}
         </div>
-        <!--
-        {{!-- Attributes Tab --}}
-        <div class="tab attributes" data-group="primary" data-tab="attributes">
-            {{!-- As you add new fields, add them in here! --}}
+		
+        {{!-- Effects Tab --}}
+        <div class="tab effects" data-group="primary" data-tab="effects">
+            <ol class="items-list effects-list">
+				<li class="item-header flexrow" data-effect-type="Item Effects">
+					<h3 class="item-name effect-name flexrow">{{localize "ICRPG.ItemEffects"}}</h3>
+					<div class="effect-source">{{localize "ICRPG.Source"}}</div>
+					<div class="effect-source">{{localize "ICRPG.Duration"}}</div>
+					<div class="item-controls effect-controls flexrow">
+						<a class="effect-control" data-action="create" title="{{localize 'ICRPG.EffectCreate'}}">
+							<i class="fas fa-plus"></i> {{localize "ICRPG.Add"}}
+						</a>
+					</div>
+				</li>
+
+				<ol class="item-list">
+				{{#each item.effects as |effect|}}
+					<li class="item effect flexrow" data-effect-id="{{effect.id}}">
+						<div class="item-name flexrow">
+							<h4>{{effect.data.label}}</h4>
+						</div>
+						<div class="effect-source">{{effect.sourceName}}</div>
+						<div class="effect-duration">{{effect.duration.label}}</div>
+						<div class="item-controls effect-controls flexrow">
+							<a class="effect-control" data-action="toggle" title="{{localize 'ICRPG.EffectToggle'}}">
+								<i class="fas {{#if effect.data.disabled}}fa-check{{else}}fa-times{{/if}}"></i>
+							</a>
+							<a class="effect-control" data-action="edit" title="{{localize 'ICRPG.EffectEdit'}}">
+								<i class="fas fa-edit"></i>
+							</a>
+							<a class="effect-control" data-action="delete" title="{{localize 'ICRPG.EffectDelete'}}">
+								<i class="fas fa-trash"></i>
+							</a>
+						</div>
+					</li>
+				{{/each}}
+				</ol>
+			</ol>
         </div>
--->
+		
+		{{!-- Rolls Tab --}}
+		<div class="tab rolls" data-group="primary" data-tab="rolls">
+			<div class="resource-content flexrow flex-center flex-between">
+				<label class="resource-label"> {{localize "ICRPG.StatRollFormula"}}: </label>
+				<input type="text" name="data.statRoll" value="{{data.data.statRoll}}"/>
+			</div>
+			<div class="resource-content flexrow flex-center flex-between">
+				<label class="resource-label"> {{localize "ICRPG.EffortRollFormula"}}:  </label>
+				<input type="text" name="data.effortRoll" value="{{data.data.effortRoll}}"/>
+			</div>
+		</div>
     </section>
 
 </form>


### PR DESCRIPTION
Howdy,

I don't know if this would be useful for everyone or if you'd like to see some changes before a merge to master, but here are some changes I've custom made for my group of players that are used to pressing things on the hotbar when playing foundry D&D 5e.  The translations still need to be done, but I think the code itself should be pretty stable.  

1) I added a listener that will roll items when their icon is pressed on the character sheet.  Items will not be rolled unless there is a formula filled out as described in the change below.  The click will roll both the stat and effort roll at the same time, with a little picture of the weapon/ability showing up in the chat window along with the roll.  

2) I added a new tab to the items/abilities sheets that allow for custom rolls to be performed.  This tab allows you to enter custom formulas for stat rolls and effort rolls.  So for example, if there is a Great Sword that always rolls ultimate dice, is always HARD to hit, and adds 2 to effort rolls, the formulas would look something like:
Stat Roll: 1d20 + @stats.str.value - 3 (the normal stat roll with a -3 because it is always hard)
Effort Roll:  1d12 + @effort.weapon.value + 2 (a d12 damage die, plus the normal weapon effort, plus an additional 2)

3) I added another new tab for item/ability EFFECTS.  This enables pieces of loot to automatically add bonuses to the loot stats on the character sheet.  For example, if you had a ring that gives +1 dex, you just need to go to the "Effects" tab, click "Add", and click "Edit".  This brings you to the normal FoundryVTT interface for editing active effects.  
In this case, you would fill out the attribute key as "data.stats.dex.loot" and the Effect Value as "1".  Then, when that item is moved to the player's inventory, that effect is applied.  

4) I added the ability for an item/ability to be dragged down to the hotbar, where it will perform the same action as if you had clicked on the item's icon.  